### PR TITLE
Change the COPY command to execute a query.

### DIFF
--- a/pg_dumpbinary
+++ b/pg_dumpbinary
@@ -260,7 +260,7 @@ foreach my $s (sort keys %tbl_list)
 		push(@{ $distributed_table{$proc} }, "\\o");
 		push(@{ $distributed_table{$proc} }, "\\echo Dumping data from table $s.$tbl_list{$s}[$i]");
 		push(@{ $distributed_table{$proc} }, qq{\\o |gzip -c - > "$OUTDIR/data-$file.bin.gz"});
-		push(@{ $distributed_table{$proc} }, qq{COPY "$s"."$tbl_list{$s}[$i]" TO stdout WITH (FORMAT binary);});
+		push(@{ $distributed_table{$proc} }, qq{COPY (SELECT * FROM "$s"."$tbl_list{$s}[$i]") TO stdout WITH (FORMAT binary);});
 		$proc++;
 		$proc = 1 if ($proc > $JOBS);
 	}


### PR DESCRIPTION
When dumping a partitioned table the server responds with

ERROR:  cannot copy from partitioned table "foo"

so it is mandatory to execute a query to get all the data out of the
partitioned table.